### PR TITLE
Change Opts to Options and improve loading toml config files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,28 +37,28 @@ const (
 	confFilePath = "local.toml"
 )
 
-// CheckConfig stores config information needed by a check
+// CheckConfig stores config information needed by a check.
 type CheckConfig struct {
-	Target           string
-	Opts             string
-	CheckID          string
-	CheckTypeName    string
-	CheckTypeVersion string
+	Target           string `toml:"Target"`
+	Opts             string `toml:"Opts"`
+	CheckID          string `toml:"CheckID"`
+	CheckTypeName    string `toml:"CheckTypeName"`
+	CheckTypeVersion string `toml:"CheckTypeVersion"`
 }
 
-// LogConfig defines configuration params for logging
+// LogConfig defines configuration params for logging.
 type LogConfig struct {
-	LogFmt   string `json:"log_fmt"`
-	LogLevel string `json:"log_level"`
+	LogFmt   string `json:"log_fmt" toml:"LogFmt"`
+	LogLevel string `json:"log_level toml:"LogLevel`
 }
 
-// Config holds all values regarding configuration
+// Config holds all values regarding configuration.
 type Config struct {
-	Check           CheckConfig `toml:"Check"`
-	Log             LogConfig   `toml:"Log"`
-	CommMode        string
+	Check           CheckConfig           `toml:"Check"`
+	Log             LogConfig             `toml:"Log"`
+	CommMode        string                `toml:"CommMode"`
 	Push            rest.RestPusherConfig `toml:"Push"`
-	AllowPrivateIPs *bool
+	AllowPrivateIPs *bool                 `toml:"AllowPrivateIps"`
 }
 
 type optionsLogConfig struct {
@@ -161,7 +161,7 @@ func overrideConfigCheckEnvVars(c *Config) {
 	}
 }
 
-// LoadConfigFromFile loads configuration file from a path
+// LoadConfigFromFile loads configuration file from a path.
 func LoadConfigFromFile(filePath string) (*Config, error) {
 	c := &Config{}
 	configData, err := ioutil.ReadFile(filePath) //nolint

--- a/config/config.go
+++ b/config/config.go
@@ -49,7 +49,7 @@ type CheckConfig struct {
 // LogConfig defines configuration params for logging.
 type LogConfig struct {
 	LogFmt   string `json:"log_fmt" toml:"LogFmt"`
-	LogLevel string `json:"log_level toml:"LogLevel`
+	LogLevel string `json:"log_level toml:"LogLevel"`
 }
 
 // Config holds all values regarding configuration.

--- a/config/config.go
+++ b/config/config.go
@@ -40,7 +40,7 @@ const (
 // CheckConfig stores config information needed by a check.
 type CheckConfig struct {
 	Target           string `toml:"Target"`
-	Opts             string `toml:"Opts"`
+	Opts             string `toml:"Options"`
 	CheckID          string `toml:"CheckID"`
 	CheckTypeName    string `toml:"CheckTypeName"`
 	CheckTypeVersion string `toml:"CheckTypeVersion"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,9 +7,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/kr/pretty"
-
 	"github.com/adevinta/vulcan-check-sdk/internal/push/rest"
+	"github.com/kr/pretty"
 )
 
 type overrideTest struct {
@@ -157,4 +156,53 @@ func setEnvVars(envVars map[string]string) error {
 		}
 	}
 	return nil
+}
+
+func TestLoadConfigFromFile(t *testing.T) {
+	type args struct {
+		filePath string
+	}
+	tests := []struct {
+		name     string
+		filepath string
+		want     *Config
+		wantErr  bool
+	}{
+		{
+			name:     "LoadsConfigFromFileProperly",
+			filepath: "testdata/LocalExample.toml",
+			want: &Config{
+				AllowPrivateIPs: new(bool),
+				CommMode:        "push",
+				Check: CheckConfig{
+					CheckID:          "id",
+					Opts:             "{\"policy\":21}",
+					Target:           "localhost:3000",
+					CheckTypeName:    "typeName",
+					CheckTypeVersion: "2",
+				},
+
+				Push: rest.RestPusherConfig{
+					AgentAddr: "http://agent:8080",
+					BufferLen: 10,
+				},
+				Log: LogConfig{
+					LogFmt:   "text",
+					LogLevel: "info",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LoadConfigFromFile(tt.filepath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadConfigFromFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Error in test %s. \nWant: %s Got: %s.\n diffs %+v", tt.name, pretty.Sprint(tt.want), pretty.Sprint(got), pretty.Diff(tt.want, got))
+			}
+		})
+	}
 }

--- a/config/testdata/LocalExample.toml
+++ b/config/testdata/LocalExample.toml
@@ -1,0 +1,17 @@
+CommMode = "push"
+AllowPrivateIPs = false
+
+[Push]
+AgentEndpoint = "http://agent:8080"
+BufferLen = 10
+
+[Check]
+Target = "localhost:3000"
+Options = "{\"policy\":21}"
+CheckId = "id"
+CheckTypeName = "typeName"
+CheckTypeVersion = "2"
+
+[Log]
+LogFmt = "text"
+LogLevel = "info"

--- a/config/testdata/OverrideTestConfig.toml
+++ b/config/testdata/OverrideTestConfig.toml
@@ -8,7 +8,7 @@ BufferLen = 10
 
 [Check]
 Target  = "localhost:3000"
-Opts = "{}"
+Options = "{}"
 CheckID ="id"
 CheckTypeName="typeName"
 CheckTypeVersion="2"
@@ -16,4 +16,3 @@ CheckTypeVersion="2"
 [Log]
 LogFmt  =  "text"
 LogLevel = "info"
-

--- a/internal/push/rest/rest_pusher.go
+++ b/internal/push/rest/rest_pusher.go
@@ -3,9 +3,8 @@ package rest
 import (
 	"fmt"
 	"net/http"
-	"sync"
-
 	"net/url"
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/resty.v1"
@@ -20,8 +19,8 @@ const (
 
 // RestPusherConfig holds the configuration needed by a RestPusher to send push notifications to the agent
 type RestPusherConfig struct {
-	AgentAddr string
-	BufferLen int
+	AgentAddr string `toml:"AgentEndpoint"`
+	BufferLen int    `toml:"BufferLen"`
 }
 
 // RestPusher communicate state changes to agent by performing http calls


### PR DESCRIPTION
This PR introduces the following modifications:

1. Sets explicitly that tags that define how the fields in a toml config must be named. 
This change intends to make clear, at least in the code, the name of the fields expected in the toml config files.

2. Modifies the field name for defining the options of a check in a toml file. Now, instead of Opts the name is Options.

3. Improves a little bit the tests for the functions related to load toml files.
