### PR TITLE
Allow RequiredVars to be specified in toml

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -49,7 +49,7 @@ type CheckConfig struct {
 // LogConfig defines configuration params for logging.
 type LogConfig struct {
 	LogFmt   string `json:"log_fmt" toml:"LogFmt"`
-	LogLevel string `json:"log_level toml:"LogLevel"`
+	LogLevel string `json:"log_level" toml:"LogLevel"`
 }
 
 // Config holds all values regarding configuration.
@@ -59,6 +59,7 @@ type Config struct {
 	CommMode        string                `toml:"CommMode"`
 	Push            rest.RestPusherConfig `toml:"Push"`
 	AllowPrivateIPs *bool                 `toml:"AllowPrivateIps"`
+	RequiredVars    map[string]string     `toml:"RequiredVars"`
 }
 
 type optionsLogConfig struct {


### PR DESCRIPTION
It will allow us to inject RequiredVars in the local.toml for testing.