### PR TITLE
Add support for inconclusive check status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 language: go
 go:
-- 1.12.7
+- 1.13.4
 env:
   global:
   - CGO_ENABLED=0

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -16,6 +16,8 @@ const (
 	StatusAborted = "ABORTED"
 	// StatusFailed represents the state for a check when has failed it's execution
 	StatusFailed = "FAILED"
+	// StatusUnreachable reporesents the state for a check when asset was not reachable.
+	StatusUnreachable = "UNREACHABLE"
 )
 
 // State holds all the data that must be sent to the agent to communicate check status and report.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -16,7 +16,7 @@ const (
 	StatusAborted = "ABORTED"
 	// StatusFailed represents the state for a check when has failed it's execution
 	StatusFailed = "FAILED"
-	// StatusInconclusive represents the state for a check when scan could not be performed correctly.
+	// StatusInconclusive represents the state for a check when it could not be executed.
 	// E.g.: Asset was unreachable.
 	StatusInconclusive = "INCONCLUSIVE"
 )

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -16,8 +16,9 @@ const (
 	StatusAborted = "ABORTED"
 	// StatusFailed represents the state for a check when has failed it's execution
 	StatusFailed = "FAILED"
-	// StatusUnreachable represents the state for a check when scanned asset was not reachable.
-	StatusUnreachable = "UNREACHABLE"
+	// StatusInconclusive represents the state for a check when scan could not be performed correctly.
+	// E.g.: Asset was unreachable.
+	StatusInconclusive = "INCONCLUSIVE"
 )
 
 // State holds all the data that must be sent to the agent to communicate check status and report.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -16,7 +16,7 @@ const (
 	StatusAborted = "ABORTED"
 	// StatusFailed represents the state for a check when has failed it's execution
 	StatusFailed = "FAILED"
-	// StatusUnreachable reporesents the state for a check when asset was not reachable.
+	// StatusUnreachable represents the state for a check when scanned asset was not reachable.
 	StatusUnreachable = "UNREACHABLE"
 )
 

--- a/internal/push/check.go
+++ b/internal/push/check.go
@@ -109,7 +109,7 @@ func (c *Check) executeChecker() {
 		if errors.Is(err, context.Canceled) {
 			log.Info("Check aborted")
 			c.checkState.SetStatusAborted()
-		} else if errors.Is(err, ErrAssetUnreachable) {
+		} else if errors.Is(err, state.ErrAssetUnreachable) {
 			log.Info("Check asset is unreachable")
 			c.checkState.SetStatusUnreachable()
 		} else {

--- a/internal/push/check.go
+++ b/internal/push/check.go
@@ -111,7 +111,7 @@ func (c *Check) executeChecker() {
 			c.checkState.SetStatusAborted()
 		} else if errors.Is(err, state.ErrAssetUnreachable) {
 			log.Info("Check asset is unreachable")
-			c.checkState.SetStatusUnreachable()
+			c.checkState.SetStatusInconclusive()
 		} else {
 			c.Logger.WithError(err).Error("Error running check")
 			c.checkState.SetStatusFailed(err)

--- a/internal/push/check.go
+++ b/internal/push/check.go
@@ -2,17 +2,18 @@ package push
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/adevinta/vulcan-check-sdk/agent"
 	"github.com/adevinta/vulcan-check-sdk/config"
 	"github.com/adevinta/vulcan-check-sdk/helpers"
 	"github.com/adevinta/vulcan-check-sdk/internal/logging"
 	"github.com/adevinta/vulcan-check-sdk/internal/push/rest"
 	"github.com/adevinta/vulcan-check-sdk/state"
+	log "github.com/sirupsen/logrus"
 )
 
 // API defines the shape the api, that basically ony listens for events to abort the check,
@@ -105,9 +106,12 @@ func (c *Check) executeChecker() {
 	elapsedTime := time.Since(startTime)
 	// If an error has been returned, we set the correct status.
 	if err != nil {
-		if err == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			log.Info("Check aborted")
 			c.checkState.SetStatusAborted()
+		} else if errors.Is(err, ErrAssetUnreachable) {
+			log.Info("Check asset is unreachable")
+			c.checkState.SetStatusUnreachable()
 		} else {
 			c.Logger.WithError(err).Error("Error running check")
 			c.checkState.SetStatusFailed(err)

--- a/internal/push/state.go
+++ b/internal/push/state.go
@@ -1,16 +1,10 @@
 package push
 
 import (
-	"errors"
 	"time"
 
 	"github.com/adevinta/vulcan-check-sdk/agent"
 	log "github.com/sirupsen/logrus"
-)
-
-var (
-	// ErrAssetUnreachable indicates that the asset to be scanned is not reachable.
-	ErrAssetUnreachable = errors.New("Asset is Unreachable")
 )
 
 // StatePusher defines the shape a pusher communications component must satisfy in order to be used

--- a/internal/push/state.go
+++ b/internal/push/state.go
@@ -1,10 +1,16 @@
 package push
 
 import (
+	"errors"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/adevinta/vulcan-check-sdk/agent"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	// ErrAssetUnreachable indicates that the asset to be scanned is not reachable.
+	ErrAssetUnreachable = errors.New("Asset is Unreachable")
 )
 
 // StatePusher defines the shape a pusher communications component must satisfy in order to be used
@@ -86,6 +92,15 @@ func (p *State) SetStatusFailed(err error) {
 	p.state.Progress = 1.0
 	p.state.Report.Error = err.Error()
 	p.state.Report.Status = agent.StatusFailed
+	p.pusher.UpdateState(p.state)
+}
+
+// SetStatusUnreachable sets the state of the current check to Unreachable and the progress to 1.0
+// This method sends a notification to the agent.
+func (p *State) SetStatusUnreachable() {
+	p.state.Status = agent.StatusUnreachable
+	p.state.Progress = 1.0
+	p.state.Report.Status = agent.StatusUnreachable
 	p.pusher.UpdateState(p.state)
 }
 

--- a/internal/push/state.go
+++ b/internal/push/state.go
@@ -89,12 +89,12 @@ func (p *State) SetStatusFailed(err error) {
 	p.pusher.UpdateState(p.state)
 }
 
-// SetStatusUnreachable sets the state of the current check to Unreachable and the progress to 1.0
+// SetStatusInconclusive sets the state of the current check to Inconclusive and the progress to 1.0
 // This method sends a notification to the agent.
-func (p *State) SetStatusUnreachable() {
-	p.state.Status = agent.StatusUnreachable
+func (p *State) SetStatusInconclusive() {
+	p.state.Status = agent.StatusInconclusive
 	p.state.Progress = 1.0
-	p.state.Report.Status = agent.StatusUnreachable
+	p.state.Report.Status = agent.StatusInconclusive
 	p.pusher.UpdateState(p.state)
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -1,7 +1,14 @@
 package state
 
 import (
-	"github.com/adevinta/vulcan-report"
+	"errors"
+
+	report "github.com/adevinta/vulcan-report"
+)
+
+var (
+	// ErrAssetUnreachable indicates that the asset to be scanned is not reachable.
+	ErrAssetUnreachable = errors.New("Asset is Unreachable")
 )
 
 // State defines the fields and function a check must use to generare a result


### PR DESCRIPTION
This PR adds support in checks SDK for a new check status `INCONCLUSIVE`. This status is a terminal status and should be the one reported when the scan of the asset was not able to be performed correctly. E.g.: Asset unreachable.

Related with:
[vulcan-agent #19](https://github.com/adevinta/vulcan-agent/pull/19)
[vulcan-persistence #51](https://github.com/adevinta/vulcan-persistence/pull/51)