### PR TITLE
Adapt IsDockerImgReachable to the specs

### DIFF
--- a/helpers/target.go
+++ b/helpers/target.go
@@ -379,14 +379,14 @@ func IsAWSAccReachable(accARN, assumeRoleURL, role string, sessDuration int) (bo
 }
 
 // IsDockerImgReachable returns whether the input Docker image exists in the
-// registry. Void user and pass does not produce an error unless a token can be
-// generated without authentication.
-// In order to verify if the Docker image exists, we perform a request to
-// registry API endpoint to get data for given image and tag.
+// registry. Void user and pass does not produce an error as long as a token
+// can be generated without authentication.
 //
-// This functionality at the moment of this writing is still not
-// implemented in Docker client, so we have to contact registry's REST API
-// directly.  Reference: https://github.com/moby/moby/issues/14254
+// In order to verify if the Docker image exists, we perform a request to
+// registry API endpoint to get data for given image and tag.  This
+// functionality at the moment of this writing is still not implemented in
+// Docker client, so we have to contact registry's REST API directly.
+// Reference: https://github.com/moby/moby/issues/14254
 func IsDockerImgReachable(target, user, pass string) (bool, error) {
 	repo, err := parseDockerRepo(target)
 	if err != nil {

--- a/helpers/target.go
+++ b/helpers/target.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -377,107 +378,170 @@ func IsAWSAccReachable(accARN, assumeRoleURL, role string, sessDuration int) (bo
 		assumeRoleResp.SessionToken), nil
 }
 
-// IsDockerImgReachable returns wether the input Docker image exists
-// in registry. Void user and pass does not produce an error and will
-// interact with registry without authentication.
+// IsDockerImgReachable returns whether the input Docker image exists in the
+// registry. Void user and pass does not produce an error unless a token can be
+// generated without authentication.
+// In order to verify if the Docker image exists, we perform a request to
+// registry API endpoint to get data for given image and tag.
+//
+// This functionality at the moment of this writing is still not
+// implemented in Docker client, so we have to contact registry's REST API
+// directly.  Reference: https://github.com/moby/moby/issues/14254
 func IsDockerImgReachable(target, user, pass string) (bool, error) {
 	repo, err := parseDockerRepo(target)
 	if err != nil {
 		return false, err
 	}
 
-	// In order to verify if Docker img exists, we perform
-	// a request to registry API endpoint to get data for
-	// given image and tag.
-	//
-	// This functionality at the moment of this writing is
-	// still not implemented in Docker client, so we have
-	// to contact registry's REST API directly.
-	// Reference: https://github.com/moby/moby/issues/14254
-
-	// Check registry version.
-	// Reference: https://docs.docker.com/registry/spec/api/#api-version-check
-	regVersion := "v1"
-	resp, err := http.Get(fmt.Sprintf("https://%s/v2/", repo.Registry))
+	token, err := dockerAPIToken(repo, user, pass)
 	if err != nil {
 		return false, err
 	}
-	if versionH, ok := resp.Header["Docker-Distribution-Api-Version"]; ok {
-		if len(versionH) >= 1 && versionH[0] == "registry/2.0" {
-			regVersion = "v2"
-		}
-	}
 
-	regBaseURL := fmt.Sprintf("https://%s/%s", repo.Registry, regVersion)
-	tagPath := fmt.Sprintf("/repositories/%s/tags/%s", repo.Img, repo.Tag)
+	// Check there exist tags for the image.
+	regBase := fmt.Sprintf("https://%s/v2/", repo.Registry)
+	tagPath := fmt.Sprintf("%s%s/%s/%s/", regBase, repo.Img, "tags", "list")
 
-	// Login if necessary.
-	var token string
-	if user != "" && pass != "" {
-		auth := struct {
-			Username string
-			Password string
-		}{
-			Username: user,
-			Password: pass,
-		}
-		rqBody, err := json.Marshal(auth)
-		if err != nil {
-			return false, err
-		}
-		req, err := http.NewRequest(http.MethodPost,
-			regBaseURL+"/users/login", bytes.NewReader(rqBody))
-		if err != nil {
-			return false, err
-		}
-		req.Header.Add("Content-Type", "application/json")
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return false, err
-		}
-		defer resp.Body.Close()
-
-		rsBody, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return false, err
-		}
-		t := struct {
-			Token string
-		}{}
-		err = json.Unmarshal(rsBody, &t)
-		if err != nil {
-			return false, err
-		}
-		token = t.Token
-	}
-
-	// Check if tag exists.
-	req, err := http.NewRequest(http.MethodGet, regBaseURL+tagPath, nil)
+	req, err := http.NewRequest(http.MethodGet, tagPath, nil)
 	if err != nil {
 		return false, err
 	}
-	if token != "" {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, err
 	}
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil || resp.StatusCode != http.StatusOK {
-		// If we did not get HTTP response, or
-		// it was not 200 OK, return false.
-		return false, nil
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("unexpected status code while checking Docker image tags: %d", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+
+	// Check that the target specified tag exists for the image.
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return false, err
+	}
+
+	img := struct {
+		Name string
+		Tags []string
+	}{}
+	if err := json.Unmarshal(body, &img); err != nil {
+		return false, err
+	}
+	if img.Name != repo.Img {
+		return false, fmt.Errorf("image differs. want: %v, have: %v", repo.Img, img.Name)
+	}
+	found := false
+	for _, tag := range img.Tags {
+		if tag == repo.Tag {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return false, errors.New("tag does not exist for the image")
 	}
 
 	return true, nil
 }
 
+// dockerAPIToken generates a bearer token for the Docker Registry API (v2).
+// Reference: https://docs.docker.com/registry/spec/api/#api-version-check
+func dockerAPIToken(repo dockerRepo, user, pass string) (string, error) {
+	// Check that the registry API supports version 2.
+	resp, err := http.Get(fmt.Sprintf("https://%s/v2/", repo.Registry))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
+		return "", fmt.Errorf("unexpected status code while checking docker registry API version: %d", resp.StatusCode)
+	}
+
+	versionH := resp.Header["Docker-Distribution-Api-Version"]
+	found := false
+	for _, v := range versionH {
+		if v == "registry/2.0" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return "", errors.New("missing or unexpected version header")
+	}
+
+	// Request token to the auth service specified via authenticate header.
+	re, err := regexp.Compile(`Bearer realm="(.+)",service="(.+)"`)
+	if err != nil {
+		return "", err
+	}
+
+	var realm string
+	var service string
+	authH := resp.Header["Www-Authenticate"]
+	found = false
+	for _, v := range authH {
+		matches := re.FindStringSubmatch(v)
+		if len(matches) == 3 {
+			found = true
+			realm = matches[1]
+			service = matches[2]
+			break
+		}
+	}
+	if !found {
+		return "", errors.New("missing or unexpected authentication header")
+	}
+
+	req, err := http.NewRequest("GET", realm, nil)
+	if err != nil {
+		return "", err
+	}
+
+	q := req.URL.Query()
+	q.Add("service", service)
+	q.Add("scope", fmt.Sprintf("repository:%s:pull", repo.Img))
+	req.URL.RawQuery = q.Encode()
+
+	if user != "" && pass != "" {
+		req.SetBasicAuth(user, pass)
+	}
+
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	t := struct {
+		Token string
+	}{}
+	if err := json.Unmarshal(body, &t); err != nil {
+		return "", err
+	}
+
+	return t.Token, nil
+}
+
 type dockerRepo struct {
 	Registry string
-	Img      string // Concat of namespace and image starting with /
+	Img      string
 	Tag      string
 }
 
 func parseDockerRepo(repo string) (dockerRepo, error) {
+	// NOTE(julianvilas): Defaulting to latest opens the door to scan images
+	// without tags.
 	tag := "latest"
+
 	imgParts := strings.Split(repo, ":")
 	if len(imgParts) == 2 && imgParts[1] != "" {
 		tag = imgParts[1]
@@ -491,7 +555,7 @@ func parseDockerRepo(repo string) (dockerRepo, error) {
 
 	return dockerRepo{
 		Registry: u.Host,
-		Img:      u.Path,
+		Img:      strings.TrimPrefix(u.Path, "/"),
 		Tag:      tag,
 	}, nil
 }

--- a/helpers/target.go
+++ b/helpers/target.go
@@ -399,10 +399,9 @@ func IsDockerImgReachable(target, user, pass string) (bool, error) {
 	}
 
 	// Check there exist tags for the image.
-	regBase := fmt.Sprintf("https://%s/v2/", repo.Registry)
-	tagPath := fmt.Sprintf("%s%s/%s/%s/", regBase, repo.Img, "tags", "list")
+	tagEndpoint := fmt.Sprintf("https://%s/v2/%s/tags/list/", repo.Registry, repo.Img)
 
-	req, err := http.NewRequest(http.MethodGet, tagPath, nil)
+	req, err := http.NewRequest(http.MethodGet, tagEndpoint, nil)
 	if err != nil {
 		return false, err
 	}

--- a/helpers/target_test.go
+++ b/helpers/target_test.go
@@ -341,7 +341,7 @@ func TestTarget_parseDockerRepo(t *testing.T) {
 			repo: "registry.hub.docker.com/library/hello-world:latest",
 			want: dockerRepo{
 				Registry: "registry.hub.docker.com",
-				Img:      "/library/hello-world",
+				Img:      "library/hello-world",
 				Tag:      "latest",
 			},
 		},
@@ -349,7 +349,7 @@ func TestTarget_parseDockerRepo(t *testing.T) {
 			repo: "artifactory.company.com/project/img_alpine:3.10.1",
 			want: dockerRepo{
 				Registry: "artifactory.company.com",
-				Img:      "/project/img_alpine",
+				Img:      "project/img_alpine",
 				Tag:      "3.10.1",
 			},
 		},

--- a/helpers/target_test.go
+++ b/helpers/target_test.go
@@ -285,33 +285,43 @@ func isAWSAccountID(accID string) bool {
 
 func TestTarget_IsDockerImgReachable(t *testing.T) {
 	testCases := []struct {
-		name   string
-		target string
-		user   string
-		pass   string
-		want   bool
+		name    string
+		target  string
+		user    string
+		pass    string
+		want    bool
+		wantErr bool
 	}{
 		{
-			name:   "Should return true, image is reachable",
-			target: "registry.hub.docker.com/library/hello-world:latest",
-			want:   true,
+			name:    "Should return true, image is reachable",
+			target:  "registry.hub.docker.com/library/hello-world:latest",
+			want:    true,
+			wantErr: false,
 		},
 		{
-			name:   "Should return false, image is NOT reachable",
-			target: "registry.hub.docker.com/library/hello-world:wrongtag",
-			want:   false,
+			name:    "Should return true, image without specified tag is reachable",
+			target:  "registry.hub.docker.com/library/hello-world",
+			want:    true,
+			wantErr: false,
 		},
 		{
-			name:   "Should return false, image is NOT reachable",
-			target: "registry.hub.docker.com/thisissomegiberishaweioanwe/giberishaweoij:latest",
-			want:   false,
+			name:    "Should return false, image with wrong tag is NOT reachable",
+			target:  "registry.hub.docker.com/library/hello-world:wrongtag",
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name:    "Should return false, image is NOT reachable",
+			target:  "registry.hub.docker.com/thisissomegiberishaweioanwe/giberishaweoij:latest",
+			want:    false,
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			isReachable, err := IsDockerImgReachable(tt.target, tt.user, tt.pass)
-			if err != nil {
+			if err != nil && !tt.wantErr {
 				t.Fatalf("Expected no error but got: %v", err)
 			}
 			if isReachable != tt.want {


### PR DESCRIPTION
The previous implementation wasn't working for Artifactory registries so
it has been adapted to meet the specs for the Docker Registry API v2.

The current approach is:
1. Check that the registry supports the API v2
2. Request a Bearer token to the authorization service that allows
   listing tags for the target image (for DockerHub this request can be
   unauthenticated)
3. List the tags of the target image and check that the target one is
   contained in there

It has been tested against DockerHub (without credentials) and
Artifactory (with credentials).

Related docs:
* https://docs.docker.com/registry/spec/auth/token/
* https://docs.docker.com/registry/spec/api/#listing-image-tags
* https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API