### PR TITLE
Panic when there is an error sending a message to the agent

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,12 +60,12 @@ type LogConfig struct {
 
 // Config holds all values regarding configuration.
 type Config struct {
-	Check           CheckConfig           `toml:"Check"`
-	Log             LogConfig             `toml:"Log"`
-	CommMode        string                `toml:"CommMode"`
-	Push            rest.RestPusherConfig `toml:"Push"`
-	AllowPrivateIPs *bool                 `toml:"AllowPrivateIps"`
-	RequiredVars    map[string]string     `toml:"RequiredVars"`
+	Check           CheckConfig       `toml:"Check"`
+	Log             LogConfig         `toml:"Log"`
+	CommMode        string            `toml:"CommMode"`
+	Push            rest.PusherConfig `toml:"Push"`
+	AllowPrivateIPs *bool             `toml:"AllowPrivateIps"`
+	RequiredVars    map[string]string `toml:"RequiredVars"`
 }
 
 type optionsLogConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,7 +56,7 @@ func TestOverrideConfigFromEnvVars(t *testing.T) {
 					CheckTypeVersion: "1",
 				},
 				CommMode: "push",
-				Push: rest.RestPusherConfig{
+				Push: rest.PusherConfig{
 					AgentAddr: "endpoint",
 					BufferLen: 11,
 				},
@@ -120,7 +120,7 @@ func TestOverrideConfigFromOpts(t *testing.T) {
 					CheckTypeVersion: "1",
 				},
 				CommMode: "push",
-				Push: rest.RestPusherConfig{
+				Push: rest.PusherConfig{
 					AgentAddr: "endpoint",
 					BufferLen: 11,
 				},
@@ -191,7 +191,7 @@ func TestLoadConfigFromFile(t *testing.T) {
 					CheckTypeVersion: "2",
 				},
 
-				Push: rest.RestPusherConfig{
+				Push: rest.PusherConfig{
 					AgentAddr: "http://agent:8080",
 					BufferLen: 10,
 				},

--- a/internal/push/check.go
+++ b/internal/push/check.go
@@ -54,7 +54,8 @@ func (c *Check) Abort() (err error) {
 	return
 }
 
-// Shutdown causes the Check to shutdown the API and the State provider. Also as a side effect, RunAndServe will also return.
+// Shutdown causes the Check to shutdown the API and the State provider. Also as
+// a side effect, RunAndServe will also return.
 func (c *Check) Shutdown() error {
 	c.Logger.Debug("Shutting down check services")
 	var err error
@@ -81,8 +82,13 @@ func (c *Check) RunAndServe() {
 	c.checkerFinished.Wait()
 	err := c.Shutdown()
 	if err != nil {
-		c.Logger.WithError(err).Error("Error trying to stop check")
+		c.Logger.WithError(err).Error("error finishing the check")
+		// If we are here it's because either there is an error in the code of
+		// the sdk or we were unable to send all the state updates to the agent,
+		// in any case we panic.
+		panic(err)
 	}
+	return
 }
 
 func (c *Check) executeChecker() {
@@ -143,7 +149,7 @@ func NewCheckWithConfig(name string, checker Checker, logger *log.Entry, conf *c
 	}
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 	pushLogger := logging.BuildRootLogWithNameAndConfig("sdk.restPusher", conf, name)
-	pussher := rest.NewRestPusher(conf.Push, conf.Check.CheckID, pushLogger)
+	pussher := rest.NewPusher(conf.Push, conf.Check.CheckID, pushLogger)
 	r := agent.NewReportFromConfig(conf.Check)
 	stateLogger := logging.BuildRootLogWithNameAndConfig("sdk.pushState", conf, name)
 	agentState := agent.State{Report: r}

--- a/internal/push/check.go
+++ b/internal/push/check.go
@@ -88,7 +88,6 @@ func (c *Check) RunAndServe() {
 		// in any case we panic.
 		panic(err)
 	}
-	return
 }
 
 func (c *Check) executeChecker() {
@@ -149,11 +148,11 @@ func NewCheckWithConfig(name string, checker Checker, logger *log.Entry, conf *c
 	}
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 	pushLogger := logging.BuildRootLogWithNameAndConfig("sdk.restPusher", conf, name)
-	pussher := rest.NewPusher(conf.Push, conf.Check.CheckID, pushLogger)
+	pusher := rest.NewPusher(conf.Push, conf.Check.CheckID, pushLogger)
 	r := agent.NewReportFromConfig(conf.Check)
 	stateLogger := logging.BuildRootLogWithNameAndConfig("sdk.pushState", conf, name)
 	agentState := agent.State{Report: r}
-	c.checkState = newState(agentState, pussher, stateLogger)
+	c.checkState = newState(agentState, pusher, stateLogger)
 	c.api = newPushAPI(logger, c)
 	// Initialize a sync point for goroutines to wait for the checker run method
 	// to be finished, for instance a call to an abort method should wait in this sync point.

--- a/internal/push/rest/rest_pusher.go
+++ b/internal/push/rest/rest_pusher.go
@@ -104,17 +104,17 @@ func NewPusher(config PusherConfig, checkID string, logger *log.Entry) *Pusher {
 
 // Pusher loops over buffered channel. Range only exits when the channel is
 // closed.
-func goPusher(c chan pusherMsg, client *resty.Client, l *log.Entry, done chan<- error) {
+func goPusher(c chan pusherMsg, client *resty.Client, l *log.Entry, finished chan<- error) {
 	go func() {
 		var err error
 		l.Debug("goPusher running")
-		defer func() { done <- err }()
+		defer func() { finished <- err }()
 		for msg := range c {
 			l.WithField("msg", msg.msg).Debug("Sending message")
 			err = sendPushMsg(msg.msg, msg.id, client, l.WithField("sendPushMsg", ""))
 			// We don't stop reading from the channel intentionally even if there is
 			// an error because we want to still try to send other messages to the agent
-			// even knowing the check would we FAILED.
+			// even knowing the check would be FAILED.
 		}
 	}()
 }

--- a/internal/push/rest/rest_pusher.go
+++ b/internal/push/rest/rest_pusher.go
@@ -5,10 +5,10 @@ Copyright 2019 Adevinta
 package rest
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
-	"sync"
 
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/resty.v1"
@@ -21,19 +21,23 @@ const (
 	agentURLBase            = "check"
 )
 
-// RestPusherConfig holds the configuration needed by a RestPusher to send push notifications to the agent
-type RestPusherConfig struct {
+// ErrSendMessage is returned by the ShutDown function when there were any error
+// trying to send a message to the agent.
+var ErrSendMessage = errors.New("error sending message to the agent")
+
+// PusherConfig holds the configuration needed by a RestPusher to send push notifications to the agent
+type PusherConfig struct {
 	AgentAddr string `toml:"AgentEndpoint"`
 	BufferLen int    `toml:"BufferLen"`
 }
 
-// RestPusher communicate state changes to agent by performing http calls
-type RestPusher struct {
+// Pusher communicate state changes to agent by performing http calls
+type Pusher struct {
 	logger     *log.Entry
 	c          *resty.Client
 	checkID    string
 	msgsToSend chan pusherMsg
-	finished   *sync.WaitGroup
+	finished   chan error
 }
 type pusherMsg struct {
 	id  string
@@ -45,7 +49,7 @@ type pusherMsg struct {
 // doesn't return any kind of error, that's because a Pusher is expected to handle
 // error in sending push messages by it's own. WARN: Calling this method after calling ShutDown
 // method will cause the program to panic.
-func (p *RestPusher) UpdateState(state interface{}) {
+func (p *Pusher) UpdateState(state interface{}) {
 	l := p.logger.WithField("msg", state)
 	l.Debug("Queuing message to be sent to the agent.")
 	select {
@@ -58,20 +62,21 @@ func (p *RestPusher) UpdateState(state interface{}) {
 }
 
 // Shutdown signals the pusher to stop accepting messages and wait for the pending messages to be send.
-func (p *RestPusher) Shutdown() {
+func (p *Pusher) Shutdown() error {
 	// Closing the pusher channel forces the pusher goroutine to send pending messages
-	// and exit
+	// and exit.
 	p.logger.Debug("Shutdown")
 	close(p.msgsToSend)
-	//Wait for pusher and queuer to finish
-	p.finished.Wait()
+	// Wait for pusher and queuer to finish.
+	err := <-p.finished
 	p.logger.Debug("Shutdown end")
+	return err
 }
 
-// NewRestPusher Creates a new push component that can be used to inform the agent state changes
+// NewPusher Creates a new push component that can be used to inform the agent state changes
 // of the check by using http rest calls.
-func NewRestPusher(config RestPusherConfig, checkID string, logger *log.Entry) *RestPusher {
-	logger.WithFields(log.Fields{"config": config, checkID: checkID}).Debug("Creating NewRestPusher with params")
+func NewPusher(config PusherConfig, checkID string, logger *log.Entry) *Pusher {
+	logger.WithFields(log.Fields{"config": config, checkID: checkID}).Debug("Creating new Pusher with params")
 	hostURL := url.URL{
 		Host:   config.AgentAddr,
 		Scheme: agentURLScheme,
@@ -84,53 +89,49 @@ func NewRestPusher(config RestPusherConfig, checkID string, logger *log.Entry) *
 	if config.BufferLen == 0 {
 		config.BufferLen = defaultPushMsgBufferLen
 	}
-	r := &RestPusher{
+	r := &Pusher{
 		c:          client,
 		checkID:    checkID,
 		msgsToSend: make(chan pusherMsg, config.BufferLen),
 		logger:     logger,
-		finished:   &sync.WaitGroup{},
+		finished:   make(chan error, 1),
 	}
 	// The wg only has to monitor pusher state
-	r.finished.Add(1)
 	goPusher(r.msgsToSend, client, logger.WithField("subcomponent", "gopusher"), r.finished)
 	logger.Debug("Creating NewRestPusher created")
 	return r
 }
 
-/* Pusher loops over buffered channel. Range only exits when the channel
-is closed. */
-func goPusher(c chan pusherMsg, client *resty.Client, l *log.Entry, wg *sync.WaitGroup) {
+// Pusher loops over buffered channel. Range only exits when the channel is
+// closed.
+func goPusher(c chan pusherMsg, client *resty.Client, l *log.Entry, done chan<- error) {
 	go func() {
-		// NOTE: race condition found #2
-		// NOTE: race condition found #3
+		var err error
 		l.Debug("goPusher running")
-		defer wg.Done()
+		defer func() { done <- err }()
 		for msg := range c {
 			l.WithField("msg", msg.msg).Debug("Sending message")
-			sendPushMsg(msg.msg, msg.id, client, l.WithField("sendPushMsg", ""))
+			err = sendPushMsg(msg.msg, msg.id, client, l.WithField("sendPushMsg", ""))
+			// We don't stop reading from the channel intentionally even if there is
+			// an error because we want to still try to send other messages to the agent
+			// even knowing the check would we FAILED.
 		}
 	}()
 }
 
-func sendPushMsg(msg interface{}, id string, c *resty.Client, l *log.Entry) {
+func sendPushMsg(msg interface{}, id string, c *resty.Client, l *log.Entry) error {
 	r := c.R()
 	r.SetBody(msg)
 	resp, err := r.Patch(id)
 	if err != nil {
-		l.WithError(err).Error("Error sending message to agent")
-		retry()
-		return
+		l.WithError(err).Error("sending message to the agent")
+		return fmt.Errorf("%w, %s", ErrSendMessage, err)
 	}
 	if resp.StatusCode() != http.StatusOK {
-		err = fmt.Errorf("Error while sending msg to agent, received status %s, expected 200", resp.Status())
-		l.WithError(err).Error("Error sending message to agent")
-		retry()
-		return
+		err = fmt.Errorf("%w, received status %s, expected 200", ErrSendMessage, resp.Status())
+		l.Error(err)
+		return err
 	}
 	l.WithField("msg", msg).Debug("Message sent to the agent")
-}
-
-func retry() {
-	// NOTE: Consider implementing retries and circuit breaking
+	return nil
 }

--- a/internal/push/state.go
+++ b/internal/push/state.go
@@ -15,7 +15,7 @@ import (
 // by the PushState. This is usefull to write unit tests because makes mocking dependencies of this component easier.
 type StatePusher interface {
 	UpdateState(state interface{})
-	Shutdown()
+	Shutdown() error
 }
 
 // State implements a state that uses a pusher to send state changes to an agent. This implementation is  NOT SYNCHRONIZED, that is not
@@ -104,8 +104,8 @@ func (p *State) SetStatusInconclusive() {
 
 // Shutdown the state gracefully.
 func (p *State) Shutdown() error {
-	p.pusher.Shutdown()
-	return nil
+	err := p.pusher.Shutdown()
+	return err
 }
 
 // newState creates a new synchronized State.


### PR DESCRIPTION
This PR introduces the following modifications:
- Modifies the sdk, so now when the sdk gets an error when sending a message to the agent, the process executing the check does not finalize with an exits code different from 0.
- Modifies the name of the component that pushes messages to the agent from "RestPusher" to "Pusher" . That makes the name better because the package where it's defined is named "rest" so "rest.Pusher" is much better than "rest.RestPusher"