### PR TITLE
Nmap helper: Optional Progress

### DIFF
--- a/helpers/nmap/nmap.go
+++ b/helpers/nmap/nmap.go
@@ -36,7 +36,6 @@ type NmapRunner interface {
 
 type runner struct {
 	params []string
-	timing int
 	state  state.State
 	output []byte
 }
@@ -108,7 +107,6 @@ func NewNmapCheck(target string, s state.State, timing int, options map[string]s
 
 	r := &runner{
 		params: params,
-		timing: timing,
 		state:  s,
 	}
 	return r

--- a/helpers/nmap/nmap_test.go
+++ b/helpers/nmap/nmap_test.go
@@ -82,13 +82,14 @@ func TestRunnerIntegrationTest(t *testing.T) {
 					ProgressReporter: stateMock{},
 				}
 				timing := 0
+				progress := true
 				port := "29070"
 				ln, err := listenOnTCPPort(port)
 				if err != nil {
 					return nil, nil, err
 				}
 
-				runner = NewNmapTCPCheck("localhost", s, timing, []string{port})
+				runner = NewNmapTCPCheck("localhost", s, timing, progress, []string{port})
 				tearDown = func() (innerError error) {
 					return (ln.Close())
 				}
@@ -105,6 +106,7 @@ func TestRunnerIntegrationTest(t *testing.T) {
 					ProgressReporter: stateMock{},
 				}
 				timing := 0
+				progress := true
 				port := "29070"
 				options := map[string]string{
 					"-p":  port,
@@ -114,7 +116,7 @@ func TestRunnerIntegrationTest(t *testing.T) {
 				if err != nil {
 					return nil, nil, err
 				}
-				runner = NewNmapCheck("localhost", s, timing, options)
+				runner = NewNmapCheck("localhost", s, timing, progress, options)
 				tearDown = func() (innerError error) {
 					return (ln.Close())
 				}
@@ -131,12 +133,13 @@ func TestRunnerIntegrationTest(t *testing.T) {
 					ProgressReporter: stateMock{},
 				}
 				timing := 0
+				progress := true
 				port := "29070"
 				ln, err := listenOnUDPPort(port)
 				if err != nil {
 					return nil, nil, err
 				}
-				runner = NewNmapUDPCheck("localhost", s, timing, []string{port})
+				runner = NewNmapUDPCheck("localhost", s, timing, progress, []string{port})
 				tearDown = func() (innerError error) {
 					return (ln.Close())
 				}
@@ -217,7 +220,8 @@ func TestProcessOutputChunk(t *testing.T) {
 	}
 	timing := 0
 	port := "29070"
-	r := NewNmapTCPCheck("localhost", s, timing, []string{port})
+	progress := true
+	r := NewNmapTCPCheck("localhost", s, timing, progress, []string{port})
 
 	chunk := []byte(`<taskprogress percent="05" \/><taskprogress a percent="15" b\/><taskprogress c percent="25" d\/>`)
 	bInfo := r.(check.ProcessChecker).ProcessOutputChunk(chunk)


### PR DESCRIPTION
Summary of changes:
- Make the "progress" report optional in the **nmap** helper provided by the SDK
- [extra] Remove unused `timing` field in the `runner` struct