### PR TITLE
Mark non-public asset checks as INCONSLUSIVE

### DIFF
--- a/internal/push/check.go
+++ b/internal/push/check.go
@@ -7,7 +7,6 @@ package push
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -108,7 +107,7 @@ func (c *Check) executeChecker() {
 		// running the check can be finalized.
 		c.checker.CleanUp(context.Background(), c.config.Check.Target, c.config.Check.AssetType, c.config.Check.Opts)
 	} else {
-		err = fmt.Errorf("target is not scannable")
+		err = state.ErrNonPublicAsset
 	}
 
 	c.checkState.SetEndTime(time.Now())
@@ -120,6 +119,9 @@ func (c *Check) executeChecker() {
 			c.checkState.SetStatusAborted()
 		} else if errors.Is(err, state.ErrAssetUnreachable) {
 			log.Info("Check asset is unreachable")
+			c.checkState.SetStatusInconclusive()
+		} else if errors.Is(err, state.ErrNonPublicAsset) {
+			log.Info("Check asset is not public")
 			c.checkState.SetStatusInconclusive()
 		} else {
 			c.Logger.WithError(err).Error("Error running check")

--- a/state/state.go
+++ b/state/state.go
@@ -13,6 +13,8 @@ import (
 var (
 	// ErrAssetUnreachable indicates that the asset to be scanned is not reachable.
 	ErrAssetUnreachable = errors.New("Asset is Unreachable")
+	// ErrNonPublicAsset indicates that the asset is not publicly exposed and therefore won't be scanned.
+	ErrNonPublicAsset = errors.New("Asset is not public")
 )
 
 // State defines the fields and function a check must use to generare a result


### PR DESCRIPTION
Vulcan can be configured to allow or prevent non-public assets (i.e. assets with no public IP address) to be scanned. Currently Vulcan fails a check when is configured to prevent scanning non-public assets and the target resolves to a private IP, and it shouldn't because it's not an error but the intended behaviour. 

This PR makes the check to be INCONCLUSIVE instead.