### PR TITLE
helpers: add flag to skip reachability test

### DIFF
--- a/helpers/target.go
+++ b/helpers/target.go
@@ -246,12 +246,12 @@ func (c *GitCreds) Password() string {
 	return c.Pass
 }
 
-// IsReachable returns whether target is reachable
-// so the check execution can be performed.
+// IsReachable returns whether target is reachable so the check
+// execution can be performed.
 //
 // ServiceCredentials are required for AWS, Docker and Git types.
-// Constructors for AWS, Docker and Git credentials can be found
-// in this same package.
+// Constructors for AWS, Docker and Git credentials can be found in
+// this same package.
 //
 // Verifications made depend on the asset type:
 //   - IP: None.
@@ -263,11 +263,16 @@ func (c *GitCreds) Password() string {
 //   - DockerImage: Check image exists in registry.
 //   - GitRepository: Git ls-remote.
 //
-// This function does not return any output related to the process in order to
-// verify the target's reachability. This output can be useful for some cases
-// in order to not repeat work in the check execution (e.g.: Obtaining the
-// Assume Role token). For this purpose other individual methods can be called
-// from this same package with further options for AWS, Docker and Git types.
+// This function does not return any output related to the process in
+// order to verify the target's reachability. This output can be
+// useful for some cases in order to not repeat work in the check
+// execution (e.g.: Obtaining the Assume Role token). For this purpose
+// other individual methods can be called from this same package with
+// further options for AWS, Docker and Git types.
+//
+// If the environment variable VULCAN_SKIP_REACHABILITY is true
+// according to [strconv.ParseBool], then the reachability test is
+// skipped and IsReachable returns true.
 func IsReachable(target, assetType string, creds ServiceCreds) (bool, error) {
 	if skipReachability() {
 		return true, nil
@@ -303,8 +308,12 @@ func IsReachable(target, assetType string, creds ServiceCreds) (bool, error) {
 	return isReachable, err
 }
 
-// IsHostnameReachable returns whether the
-// input hostname target can be resolved.
+// IsHostnameReachable returns whether the input hostname target can
+// be resolved.
+//
+// If the environment variable VULCAN_SKIP_REACHABILITY is true
+// according to [strconv.ParseBool], then the reachability test is
+// skipped and IsHostnameReachable returns true.
 func IsHostnameReachable(target string) bool {
 	if skipReachability() {
 		return true
@@ -319,8 +328,12 @@ func IsHostnameReachable(target string) bool {
 	return true
 }
 
-// IsWebAddrsReachable returns whether the
-// input web address accepts HTTP requests.
+// IsWebAddrsReachable returns whether the input web address accepts
+// HTTP requests.
+//
+// If the environment variable VULCAN_SKIP_REACHABILITY is true
+// according to [strconv.ParseBool], then the reachability test is
+// skipped and IsWebAddrsReachable returns true.
 func IsWebAddrsReachable(target string) bool {
 	if skipReachability() {
 		return true
@@ -333,9 +346,13 @@ func IsWebAddrsReachable(target string) bool {
 	return true
 }
 
-// IsDomainReachable returns whether the input target
-// is a reachable Domain Name. The criteria to determine
-// a target as a Domain is the existence of a SOA record.
+// IsDomainReachable returns whether the input target is a reachable
+// Domain Name. The criteria to determine a target as a Domain is the
+// existence of a SOA record.
+//
+// If the environment variable VULCAN_SKIP_REACHABILITY is true
+// according to [strconv.ParseBool], then the reachability test is
+// skipped and IsDomainReachable returns true.
 func IsDomainReachable(target string) (bool, error) {
 	if skipReachability() {
 		return true, nil
@@ -344,9 +361,14 @@ func IsDomainReachable(target string) (bool, error) {
 	return types.IsDomainName(target)
 }
 
-// IsAWSAccReachable returns whether the AWS account associated with the input ARN
-// allows to assume role with the given params through the vulcan-assume-role service.
-// If role is assumed correctly for the given account, STS credentials are returned.
+// IsAWSAccReachable returns whether the AWS account associated with
+// the input ARN allows to assume role with the given params through
+// the vulcan-assume-role service. If role is assumed correctly for
+// the given account, STS credentials are returned.
+//
+// If the environment variable VULCAN_SKIP_REACHABILITY is true
+// according to [strconv.ParseBool], then the reachability test is
+// skipped and IsAWSAccReachable returns true and no STS credentials.
 func IsAWSAccReachable(accARN, assumeRoleURL, role string, sessDuration int) (bool, *credentials.Credentials, error) {
 	if skipReachability() {
 		return true, nil, nil
@@ -404,15 +426,19 @@ func IsAWSAccReachable(accARN, assumeRoleURL, role string, sessDuration int) (bo
 		assumeRoleResp.SessionToken), nil
 }
 
-// IsDockerImgReachable returns whether the input Docker image exists in the
-// registry. Void user and pass does not produce an error as long as a token
-// can be generated without authentication.
+// IsDockerImgReachable returns whether the input Docker image exists
+// in the registry. Void user and pass does not produce an error as
+// long as a token can be generated without authentication.
 //
-// In order to verify if the Docker image exists, we perform a request to
-// registry API endpoint to get data for given image and tag.  This
-// functionality at the moment of this writing is still not implemented in
-// Docker client, so we have to contact registry's REST API directly.
-// Reference: https://github.com/moby/moby/issues/14254
+// In order to verify if the Docker image exists, we perform a request
+// to registry API endpoint to get data for given image and tag. This
+// functionality at the moment of this writing is still not
+// implemented in Docker client, so we have to contact registry's REST
+// API directly. Reference: https://github.com/moby/moby/issues/14254
+//
+// If the environment variable VULCAN_SKIP_REACHABILITY is true
+// according to [strconv.ParseBool], then the reachability test is
+// skipped and IsDockerImgReachable returns true.
 func IsDockerImgReachable(target, user, pass string) (bool, error) {
 	if skipReachability() {
 		return true, nil
@@ -589,9 +615,13 @@ func parseDockerRepo(repo string) (dockerRepo, error) {
 	}, nil
 }
 
-// IsGitRepoReachable returns whether the input Git repository is reachable
-// by performing a ls-remote.
-// If no authentication is required, user and pass parameters can be void.
+// IsGitRepoReachable returns whether the input Git repository is
+// reachable by performing a ls-remote. If no authentication is
+// required, user and pass parameters can be void.
+//
+// If the environment variable VULCAN_SKIP_REACHABILITY is true
+// according to [strconv.ParseBool], then the reachability test is
+// skipped and IsGitRepoReachable returns true.
 func IsGitRepoReachable(target, user, pass string) bool {
 	if skipReachability() {
 		return true

--- a/helpers/target.go
+++ b/helpers/target.go
@@ -163,9 +163,9 @@ func isAllowed(addr string) (bool, error) {
 // necessary to access an authenticated service.
 // There are constructors available in this same
 // package for:
-//    - AWS Assume role through vulcan-assume-role svc.
-//    - Docker registry.
-//    - Github repository.
+//   - AWS Assume role through vulcan-assume-role svc.
+//   - Docker registry.
+//   - Github repository.
 type ServiceCreds interface {
 	URL() string
 	Username() string
@@ -254,14 +254,14 @@ func (c *GitCreds) Password() string {
 // in this same package.
 //
 // Verifications made depend on the asset type:
-//    - IP: None.
-//    - IPRange: None.
-//    - Hostname: NS Lookup resolution.
-//    - WebAddress: HTTP GET request.
-//    - DomainName: NS Lookup checking SOA record.
-//    - AWSAccount: Assume Role.
-//    - DockerImage: Check image exists in registry.
-//    - GitRepository: Git ls-remote.
+//   - IP: None.
+//   - IPRange: None.
+//   - Hostname: NS Lookup resolution.
+//   - WebAddress: HTTP GET request.
+//   - DomainName: NS Lookup checking SOA record.
+//   - AWSAccount: Assume Role.
+//   - DockerImage: Check image exists in registry.
+//   - GitRepository: Git ls-remote.
 //
 // This function does not return any output related to the process in order to
 // verify the target's reachability. This output can be useful for some cases

--- a/helpers/target_test.go
+++ b/helpers/target_test.go
@@ -99,6 +99,7 @@ func TestTarget_IsHostnameReachable(t *testing.T) {
 	testCases := []struct {
 		name   string
 		target string
+		skip   string
 		want   bool
 	}{
 		{
@@ -111,10 +112,18 @@ func TestTarget_IsHostnameReachable(t *testing.T) {
 			target: "thisIsProbablyAnUnexistentHostnameIReallyHope.com",
 			want:   false,
 		},
+		{
+			name:   "Skip reachability check",
+			target: "thisIsProbablyAnUnexistentHostnameIReallyHope.com",
+			skip:   "true",
+			want:   true,
+		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envSkipReachability, tt.skip)
+
 			if isReachable := IsHostnameReachable(tt.target); isReachable != tt.want {
 				t.Fatalf("Expected reachability for %s to be %v, but got %v",
 					tt.target, tt.want, isReachable)
@@ -127,6 +136,7 @@ func TestTarget_IsWebAddrsReachable(t *testing.T) {
 	testCases := []struct {
 		name   string
 		target string
+		skip   string
 		want   bool
 	}{
 		{
@@ -139,10 +149,18 @@ func TestTarget_IsWebAddrsReachable(t *testing.T) {
 			target: "http://www.thisIsProbablyAnUnexistentHostnameIReallyHope.com",
 			want:   false,
 		},
+		{
+			name:   "Skip reachability check",
+			target: "http://www.thisIsProbablyAnUnexistentHostnameIReallyHope.com",
+			skip:   "true",
+			want:   true,
+		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envSkipReachability, tt.skip)
+
 			if isReachable := IsWebAddrsReachable(tt.target); isReachable != tt.want {
 				t.Fatalf("Expected reachability for %s to be %v, but got %v",
 					tt.target, tt.want, isReachable)
@@ -230,6 +248,7 @@ func TestTarget_IsAWSAccReachable(t *testing.T) {
 		name       string
 		input      input
 		srvHandler http.Handler
+		skip       string
 		want       bool
 		wantCreds  *credentials.Credentials
 	}{
@@ -256,10 +275,22 @@ func TestTarget_IsAWSAccReachable(t *testing.T) {
 			srvHandler: koHandler,
 			want:       false,
 		},
+		{
+			name: "Skip reachability check",
+			input: input{
+				accID: "arn:aws:iam::111111111111:root",
+				role:  "role2",
+			},
+			srvHandler: koHandler,
+			skip:       "true",
+			want:       true,
+		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envSkipReachability, tt.skip)
+
 			testSrv := httptest.NewServer(tt.srvHandler)
 
 			isReachable, creds, err := IsAWSAccReachable(tt.input.accID, testSrv.URL, tt.input.role, tt.input.sessDuration)
@@ -293,6 +324,7 @@ func TestTarget_IsDockerImgReachable(t *testing.T) {
 		target  string
 		user    string
 		pass    string
+		skip    string
 		want    bool
 		wantErr bool
 	}{
@@ -320,10 +352,19 @@ func TestTarget_IsDockerImgReachable(t *testing.T) {
 			want:    false,
 			wantErr: true,
 		},
+		{
+			name:    "Skip reachability check",
+			target:  "registry.hub.docker.com/thisissomegiberishaweioanwe/giberishaweoij:latest",
+			skip:    "true",
+			want:    true,
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envSkipReachability, tt.skip)
+
 			isReachable, err := IsDockerImgReachable(tt.target, tt.user, tt.pass)
 			if err != nil && !tt.wantErr {
 				t.Fatalf("Expected no error but got: %v", err)
@@ -380,6 +421,7 @@ func TestTarget_IsGitRepoReachable(t *testing.T) {
 	testCases := []struct {
 		name  string
 		input input
+		skip  string
 		want  bool
 	}{
 		{
@@ -396,10 +438,20 @@ func TestTarget_IsGitRepoReachable(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "Skip reachability check",
+			input: input{
+				target: "https://github.com/adevinta/thisissomegiberishaweno.git",
+			},
+			skip: "true",
+			want: true,
+		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envSkipReachability, tt.skip)
+
 			isReachable := IsGitRepoReachable(tt.input.target, tt.input.user, tt.input.pass)
 			if isReachable != tt.want {
 				t.Fatalf("Expected Git repo '%s' reachability to be %v, but got %v",


### PR DESCRIPTION
This PR adds a runtime flag that allows to skip the reachability test
performed by checks. This is useful, for instance, when running checks
against local Docker images.