### PR TITLE
helpers: compare case insensitive tags

### DIFF
--- a/helpers/target.go
+++ b/helpers/target.go
@@ -488,9 +488,10 @@ func IsDockerImgReachable(target, user, pass string) (bool, error) {
 	if img.Name != repo.Img {
 		return false, fmt.Errorf("image differs. want: %v, have: %v", repo.Img, img.Name)
 	}
+	rt := strings.ToLower(repo.Tag)
 	found := false
 	for _, tag := range img.Tags {
-		if tag == repo.Tag {
+		if strings.ToLower(tag) == rt {
 			found = true
 			break
 		}


### PR DESCRIPTION
The JFrog Artifactory container registry supports querying/pulling
images by case insensitive tags, but tags retrieved by the
registry's 'repository/tags/list' endpoint are returned exactly as they were
pushed.

This commit makes the 'IsDockerImgReachable' to behave the same way the
registry behaves.
