### PR TITLE
Fix path in Docker tags list registry endpoint

### DIFF
--- a/helpers/target.go
+++ b/helpers/target.go
@@ -455,7 +455,7 @@ func IsDockerImgReachable(target, user, pass string) (bool, error) {
 	}
 
 	// Check there exist tags for the image.
-	tagEndpoint := fmt.Sprintf("https://%s/v2/%s/tags/list/", repo.Registry, repo.Img)
+	tagEndpoint := fmt.Sprintf("https://%s/v2/%s/tags/list", repo.Registry, repo.Img)
 
 	req, err := http.NewRequest(http.MethodGet, tagEndpoint, nil)
 	if err != nil {


### PR DESCRIPTION
This PR fix issues found in some Docker image registries which a trailing slash in the `/tags/list` endpoint produced an unexpected response code and was making DockerImage isReachable check to fail.

CNCF HTTP API V2 image registry [documentation](https://distribution.github.io/distribution/spec/api/#listing-image-tags) `/tags/list` endpoint does not include a trailing slash.